### PR TITLE
:bug: Format Google Docs links as Markdown

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,33 @@
+import { googleDocsToMarkdown } from "./index";
+
+describe("googleDocsToMarkdown", () => {
+  it("formats linked text as valid Markdown links", () => {
+    const markdown = googleDocsToMarkdown({
+      title: "Linked document",
+      documentId: "doc-1",
+      revisionId: "rev-1",
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [
+                { textRun: { content: "Read " } },
+                {
+                  textRun: {
+                    content: "the docs",
+                    textStyle: {
+                      link: { url: "https://example.com/docs" },
+                    },
+                  },
+                },
+                { textRun: { content: " today" } },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(markdown).toContain("Read [the docs](https://example.com/docs) today");
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -164,6 +164,6 @@ const content = (
   const textRun = element?.textRun;
   const text = textRun?.content;
   if (textRun?.textStyle?.link?.url)
-    return `[${text}]${textRun.textStyle.link.url}`;
+    return `[${text}](${textRun.textStyle.link.url})`;
   return text || undefined;
 };


### PR DESCRIPTION
## Summary
- Fixes Google Docs link conversion so linked text is emitted as valid Markdown (`[text](url)`) instead of `[text]url`
- Adds a focused regression test for linked paragraph text

## Test plan
- `npm test -- --runInBand`
- `npm run build`
- `npx -y -p node@12 node ./node_modules/typescript/bin/tsc`
- `npx -y -p node@12 node ./node_modules/jest/bin/jest.js --runInBand`

