### PR TITLE
:construction_worker: Restore Node CI on modern runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,56 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
 jobs:
-  release:
-    name: Build, test, and release
-    runs-on: ubuntu-18.04
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Build TypeScript
         run: npm run build
+      - name: Test
+        run: npm test -- --runInBand
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 12
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build TypeScript
+        run: npm run build
+      - name: Test
+        run: npm test -- --runInBand
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Moves Node CI off the retired `ubuntu-18.04` runner that left the post-merge workflow queued
- Adds PR build/test coverage while keeping release restricted to pushes on `master`
- Updates checkout/setup-node actions and scopes write permissions to the release job only

## Test plan
- `actionlint` via stdin for `.github/workflows/release.yml`
- `npm test -- --runInBand`
- `npm run build`

